### PR TITLE
Add unit testing using XCTest

### DIFF
--- a/Core Data.xctestplan
+++ b/Core Data.xctestplan
@@ -1,0 +1,24 @@
+{
+  "configurations" : [
+    {
+      "id" : "3CDB4459-4899-4211-AC49-16B7072D63CC",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "testTimeoutsEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:Pack Buddy.xcodeproj",
+        "identifier" : "A7A591C62CE1FA84001E7898",
+        "name" : "PackBuddyTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Pack Buddy.xcodeproj/project.pbxproj
+++ b/Pack Buddy.xcodeproj/project.pbxproj
@@ -46,6 +46,16 @@
 		A7E1ADC92CB1459800AF3944 /* AddItemCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7E1ADC62CB1459800AF3944 /* AddItemCell.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		A7A591CB2CE1FA84001E7898 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A7CE0C632C9AD8C80037DFBB /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A7CE0C6A2C9AD8C80037DFBB;
+			remoteInfo = "Pack Buddy";
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
 		A71601052CB3C4060054D793 /* PackingsHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackingsHeaderView.swift; sourceTree = "<group>"; };
 		A71601072CB3C4240054D793 /* PackingsHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PackingsHeaderView.xib; sourceTree = "<group>"; };
@@ -66,6 +76,7 @@
 		A743487B2CB7EE5C00D40F54 /* ItemsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemsViewController.swift; sourceTree = "<group>"; };
 		A743487D2CB7F91500D40F54 /* UIColorTransformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColorTransformer.swift; sourceTree = "<group>"; };
 		A74348852CB95F8600D40F54 /* PackingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackingViewModel.swift; sourceTree = "<group>"; };
+		A7A591C72CE1FA84001E7898 /* PackBuddyTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PackBuddyTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A7CE0C6B2C9AD8C80037DFBB /* Pack Buddy.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Pack Buddy.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A7CE0C6E2C9AD8C80037DFBB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A7CE0C702C9AD8C80037DFBB /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -90,9 +101,17 @@
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		A74348832CB93A4800D40F54 /* Fonts */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Fonts; sourceTree = "<group>"; };
+		A7A591C82CE1FA84001E7898 /* PackBuddyTests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = PackBuddyTests; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		A7A591C42CE1FA84001E7898 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A7CE0C682C9AD8C80037DFBB /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -184,6 +203,7 @@
 			isa = PBXGroup;
 			children = (
 				A7CE0C6D2C9AD8C80037DFBB /* Pack Buddy */,
+				A7A591C82CE1FA84001E7898 /* PackBuddyTests */,
 				A7CE0C6C2C9AD8C80037DFBB /* Products */,
 			);
 			sourceTree = "<group>";
@@ -192,6 +212,7 @@
 			isa = PBXGroup;
 			children = (
 				A7CE0C6B2C9AD8C80037DFBB /* Pack Buddy.app */,
+				A7A591C72CE1FA84001E7898 /* PackBuddyTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -248,6 +269,29 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		A7A591C62CE1FA84001E7898 /* PackBuddyTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A7A591CD2CE1FA84001E7898 /* Build configuration list for PBXNativeTarget "PackBuddyTests" */;
+			buildPhases = (
+				A7A591C32CE1FA84001E7898 /* Sources */,
+				A7A591C42CE1FA84001E7898 /* Frameworks */,
+				A7A591C52CE1FA84001E7898 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A7A591CC2CE1FA84001E7898 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				A7A591C82CE1FA84001E7898 /* PackBuddyTests */,
+			);
+			name = PackBuddyTests;
+			packageProductDependencies = (
+			);
+			productName = PackBuddyTests;
+			productReference = A7A591C72CE1FA84001E7898 /* PackBuddyTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		A7CE0C6A2C9AD8C80037DFBB /* Pack Buddy */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = A7CE0C822C9AD8C90037DFBB /* Build configuration list for PBXNativeTarget "Pack Buddy" */;
@@ -275,9 +319,13 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1540;
+				LastSwiftUpdateCheck = 1610;
 				LastUpgradeCheck = 1540;
 				TargetAttributes = {
+					A7A591C62CE1FA84001E7898 = {
+						CreatedOnToolsVersion = 16.1;
+						TestTargetID = A7CE0C6A2C9AD8C80037DFBB;
+					};
 					A7CE0C6A2C9AD8C80037DFBB = {
 						CreatedOnToolsVersion = 15.4;
 					};
@@ -297,11 +345,19 @@
 			projectRoot = "";
 			targets = (
 				A7CE0C6A2C9AD8C80037DFBB /* Pack Buddy */,
+				A7A591C62CE1FA84001E7898 /* PackBuddyTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		A7A591C52CE1FA84001E7898 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A7CE0C692C9AD8C80037DFBB /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -324,6 +380,13 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		A7A591C32CE1FA84001E7898 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A7CE0C672C9AD8C80037DFBB /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -358,6 +421,14 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		A7A591CC2CE1FA84001E7898 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A7CE0C6A2C9AD8C80037DFBB /* Pack Buddy */;
+			targetProxy = A7A591CB2CE1FA84001E7898 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin PBXVariantGroup section */
 		A7CE0C742C9AD8C80037DFBB /* Main.storyboard */ = {
 			isa = PBXVariantGroup;
@@ -378,6 +449,44 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		A7A591CE2CE1FA84001E7898 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 6Y7VSJ5XSR;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = jonathanvieri.PackBuddyTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Pack Buddy.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Pack Buddy";
+			};
+			name = Debug;
+		};
+		A7A591CF2CE1FA84001E7898 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 6Y7VSJ5XSR;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = jonathanvieri.PackBuddyTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Pack Buddy.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Pack Buddy";
+			};
+			name = Release;
+		};
 		A7CE0C802C9AD8C90037DFBB /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -562,6 +671,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		A7A591CD2CE1FA84001E7898 /* Build configuration list for PBXNativeTarget "PackBuddyTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A7A591CE2CE1FA84001E7898 /* Debug */,
+				A7A591CF2CE1FA84001E7898 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		A7CE0C662C9AD8C80037DFBB /* Build configuration list for PBXProject "Pack Buddy" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Pack Buddy.xcodeproj/project.pbxproj
+++ b/Pack Buddy.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		A743487C2CB7EE5C00D40F54 /* ItemsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A743487B2CB7EE5C00D40F54 /* ItemsViewController.swift */; };
 		A743487E2CB7F91A00D40F54 /* UIColorTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A743487D2CB7F91500D40F54 /* UIColorTransformer.swift */; };
 		A74348862CB95F8900D40F54 /* PackingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A74348852CB95F8600D40F54 /* PackingViewModel.swift */; };
+		A7A591E92CE377CF001E7898 /* Core Data.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = A7A591E82CE377CF001E7898 /* Core Data.xctestplan */; };
 		A7CE0C6F2C9AD8C80037DFBB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7CE0C6E2C9AD8C80037DFBB /* AppDelegate.swift */; };
 		A7CE0C712C9AD8C80037DFBB /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7CE0C702C9AD8C80037DFBB /* SceneDelegate.swift */; };
 		A7CE0C762C9AD8C80037DFBB /* Base in Resources */ = {isa = PBXBuildFile; fileRef = A7CE0C752C9AD8C80037DFBB /* Base */; };
@@ -77,6 +78,7 @@
 		A743487D2CB7F91500D40F54 /* UIColorTransformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColorTransformer.swift; sourceTree = "<group>"; };
 		A74348852CB95F8600D40F54 /* PackingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackingViewModel.swift; sourceTree = "<group>"; };
 		A7A591C72CE1FA84001E7898 /* PackBuddyTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PackBuddyTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		A7A591E82CE377CF001E7898 /* Core Data.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Core Data.xctestplan"; sourceTree = "<group>"; };
 		A7CE0C6B2C9AD8C80037DFBB /* Pack Buddy.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Pack Buddy.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A7CE0C6E2C9AD8C80037DFBB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A7CE0C702C9AD8C80037DFBB /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -202,6 +204,7 @@
 		A7CE0C622C9AD8C80037DFBB = {
 			isa = PBXGroup;
 			children = (
+				A7A591E82CE377CF001E7898 /* Core Data.xctestplan */,
 				A7CE0C6D2C9AD8C80037DFBB /* Pack Buddy */,
 				A7A591C82CE1FA84001E7898 /* PackBuddyTests */,
 				A7CE0C6C2C9AD8C80037DFBB /* Products */,
@@ -355,6 +358,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A7A591E92CE377CF001E7898 /* Core Data.xctestplan in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Pack Buddy.xcodeproj/xcshareddata/xcschemes/Pack Buddy.xcscheme
+++ b/Pack Buddy.xcodeproj/xcshareddata/xcschemes/Pack Buddy.xcscheme
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1610"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A7CE0C6A2C9AD8C80037DFBB"
+               BuildableName = "Pack Buddy.app"
+               BlueprintName = "Pack Buddy"
+               ReferencedContainer = "container:Pack Buddy.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:Core Data Functionality.xctestplan">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:Core Data.xctestplan">
+         </TestPlanReference>
+      </TestPlans>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A7A591C62CE1FA84001E7898"
+               BuildableName = "PackBuddyTests.xctest"
+               BlueprintName = "PackBuddyTests"
+               ReferencedContainer = "container:Pack Buddy.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A7CE0C6A2C9AD8C80037DFBB"
+            BuildableName = "Pack Buddy.app"
+            BlueprintName = "Pack Buddy"
+            ReferencedContainer = "container:Pack Buddy.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A7CE0C6A2C9AD8C80037DFBB"
+            BuildableName = "Pack Buddy.app"
+            BlueprintName = "Pack Buddy"
+            ReferencedContainer = "container:Pack Buddy.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Pack Buddy/Utilities/CoreDataManager.swift
+++ b/Pack Buddy/Utilities/CoreDataManager.swift
@@ -129,7 +129,6 @@ class CoreDataManager {
         return items
     }
     
-    //
     func createItemsFromTitles(_ titles: [String]) -> [Item] {
         var items = [Item]()
         

--- a/Pack Buddy/Utilities/CoreDataManager.swift
+++ b/Pack Buddy/Utilities/CoreDataManager.swift
@@ -108,7 +108,6 @@ class CoreDataManager {
     
     //MARK: - Items Methods
     
-    //
     func createItemsFromSelectedTemplates(selectedTemplate: TemplateModel) -> [Item] {
         var items = [Item]()
         

--- a/Pack Buddy/Utilities/CoreDataManager.swift
+++ b/Pack Buddy/Utilities/CoreDataManager.swift
@@ -11,20 +11,26 @@ import CoreData
 class CoreDataManager {
     static let shared = CoreDataManager()
     
-    // MARK: - Core Data Stack
-    lazy var persistentContainer: NSPersistentContainer = {
-        let container = NSPersistentContainer(name: "PackBuddy")
-        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
-            if let error = error as NSError? {
-                fatalError("Unresolved error \(error), \(error.userInfo)")
-            }
-        })
-        return container
-    }()
+    let persistentContainer: NSPersistentContainer
     
     // Context to interact with Core Data
     var context: NSManagedObjectContext {
         return persistentContainer.viewContext
+    }
+    
+    // Default initializer
+    private init() {
+        self.persistentContainer = NSPersistentContainer(name: "PackBuddy")
+        persistentContainer.loadPersistentStores(completionHandler: { (storeDescription, error) in
+            if let error = error as NSError? {
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        })
+    }
+    
+    // Custom initializer for testing, allowing injection of different NSPersistentContainer
+    init(container: NSPersistentContainer) {
+        self.persistentContainer = container
     }
 
     // MARK: - Core Data Saving support
@@ -76,7 +82,7 @@ class CoreDataManager {
         fetchRequest.sortDescriptors = [sortDescriptor]
         
         do {
-            let sortedPackings = try CoreDataManager.shared.context.fetch(fetchRequest)
+            let sortedPackings = try context.fetch(fetchRequest)
             return sortedPackings
         } catch {
             print("Error fetching packings: \(error)")

--- a/PackBuddyTests/CategoryTests.swift
+++ b/PackBuddyTests/CategoryTests.swift
@@ -1,0 +1,162 @@
+//
+//  CategoryTests.swift
+//  PackBuddyTests
+//
+//  Created by Jonathan Vieri on 12/11/24.
+//
+
+import XCTest
+import CoreData
+
+@testable import Pack_Buddy
+
+final class CategoryTests: XCTestCase {
+
+    //MARK: - Setup
+    lazy var persistentContainer: NSPersistentContainer = {
+        let container = NSPersistentContainer(name: "PackBuddy")
+        
+        let descriptor = NSPersistentStoreDescription()
+        descriptor.type = NSInMemoryStoreType
+        container.persistentStoreDescriptions = [descriptor]
+        
+        container.loadPersistentStores { (storeDescription, error) in
+            if let error = error {
+                fatalError("Failed to load in-memory Core Data store: \(error.localizedDescription)")
+            }
+        }
+        
+        return container
+    }()
+
+    var context: NSManagedObjectContext {
+        return persistentContainer.viewContext
+    }
+    
+    var coreDataManager: CoreDataManager!
+    
+    override func setUp() {
+        super.setUp()
+        coreDataManager = CoreDataManager(container: persistentContainer)
+    }
+    
+    override func tearDown() {
+        coreDataManager = nil
+        super.tearDown()
+    }
+    
+    //MARK: - Positive Test Cases
+    func testCreateCategoryForPacking() {
+        // Given: Create a new packing entity
+        let newPacking = coreDataManager.createNewPacking(
+            title: "Trip to Georgia",
+            location: "City",
+            startDate: Date(),
+            endDate: Date().addingTimeInterval(86400),
+            color: UIColor.red
+        )
+        
+        // When: Create a Category associated with the newly created packing
+        let title = "Documents"
+        let symbol = "folder"
+        
+        let category = coreDataManager.createNewCategory(
+            title: title,
+            symbol: symbol,
+            packing: newPacking
+        )
+        
+        // Then: Verify that the category was created and associated correctly
+        XCTAssertEqual(category.title, title, "Category title is incorrect")
+        XCTAssertEqual(category.symbol, symbol, "Category symbol is incorrect")
+        XCTAssertEqual(category.parentPacking, newPacking, "Category should be linked to the newly created Packing")
+        
+        XCTAssertEqual(newPacking.categories?.count, 1, "Packing should contain one category")
+    }
+    
+    func testFetchCategoriesForPacking() {
+        // Given: Create a new Packing with some Categories
+        let newPacking = coreDataManager.createNewPacking(
+            title: "Trip to Alaska",
+            location: "Mountain",
+            startDate: Date(),
+            endDate: Date().addingTimeInterval(86400),
+            color: UIColor.blue
+        )
+        
+        let firstCategory = coreDataManager.createNewCategory(
+            title: "Documents",
+            symbol: "folder",
+            packing: newPacking
+        )
+        
+        let secondCategory = coreDataManager.createNewCategory(
+            title: "Basketball Gears",
+            symbol: "basketball",
+            packing: newPacking
+        )
+        
+        // When: Fetch all categories related with the created Packing
+        let categories = newPacking.categories?.allObjects as? [Pack_Buddy.Category]
+        
+        // Then: Verify that correct Categories are fetche
+        XCTAssertEqual(categories?.count, 2, "There should only be two Categories for the newly created Packing")
+        XCTAssertTrue(categories?.contains(firstCategory) ?? false, "First category should be in fetched categories")
+        XCTAssertTrue(categories?.contains(secondCategory) ?? false, "Second category should be in fetched categories")
+    }
+    
+    //MARK: - Negative Test Cases
+    func testCreateCategoryWithMissingFields() {
+        // Given: Create a new Packing
+        let newPacking = coreDataManager.createNewPacking(
+            title: "Hiking Mt Semeru",
+            location: "Mountain",
+            startDate: Date(),
+            endDate: Date().addingTimeInterval(86400),
+            color: UIColor.blue
+        )
+        
+        // When: Create new Category with missing fields
+        let category = Category(context: coreDataManager.context)
+        category.title = nil
+        category.symbol = nil
+        category.parentPacking = newPacking
+        
+        // Then: Try saving Category with missing fields
+        do {
+            try coreDataManager.context.save()
+            XCTFail("Saving category with missing fields should have failed")
+        } catch {
+            XCTAssertNotNil(error, "Expected an error due to missing fields during Category creation")
+        }
+    }
+    
+    func testFetchCategoryWithInvalidPredicate() {
+        // Given: Create a Packing and a Category associated to it
+        let newPacking = coreDataManager.createNewPacking(
+            title: "Swimming in Bahamas",
+            location: "Beach",
+            startDate: Date(),
+            endDate: Date().addingTimeInterval(86400),
+            color: UIColor.blue
+        )
+        
+        let _ = coreDataManager.createNewCategory(
+            title: "Sport Stuff",
+            symbol: "basketball",
+            packing: newPacking
+        )
+        
+        // When: Fetch Categories with predicate that won't match any existing Categories
+        let fetchRequest: NSFetchRequest<Pack_Buddy.Category> =  Category.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "title == %@", "Unknown Category")
+        
+        // Then: Fetch should return empty collection and not throw any errors
+        do {
+            let results = try coreDataManager.context.fetch(fetchRequest)
+            XCTAssertTrue(results.isEmpty, "Expected no results for invalid predicate")
+        } catch {
+            XCTFail("Fetching with invalid predicate should not throw an error")
+        }
+    }
+}

--- a/PackBuddyTests/ItemsTests.swift
+++ b/PackBuddyTests/ItemsTests.swift
@@ -1,0 +1,231 @@
+//
+//  ItemsTests.swift
+//  PackBuddyTests
+//
+//  Created by Jonathan Vieri on 12/11/24.
+//
+
+import XCTest
+import CoreData
+
+@testable import Pack_Buddy
+
+final class ItemsTests: XCTestCase {
+
+    //MARK: - Setup
+    lazy var persistentContainer: NSPersistentContainer = {
+        let container = NSPersistentContainer(name: "PackBuddy")
+        
+        let descriptor = NSPersistentStoreDescription()
+        descriptor.type = NSInMemoryStoreType
+        container.persistentStoreDescriptions = [descriptor]
+        
+        container.loadPersistentStores { (storeDescription, error) in
+            if let error = error {
+                fatalError("Failed to load in-memory Core Data store with error: \(error.localizedDescription)")
+            }
+        }
+        return container
+    }()
+
+    var context: NSManagedObjectContext {
+        return persistentContainer.viewContext
+    }
+    
+    var coreDataManager: CoreDataManager!
+    
+    override func setUp() {
+        super.setUp()
+        coreDataManager = CoreDataManager(container: persistentContainer)
+    }
+    
+    override func tearDown() {
+        coreDataManager = nil
+        super.tearDown()
+    }
+    
+    //MARK: - Positive Test Cases
+    
+    func testCreateItemInCategory() {
+        // Given: Create a Packing and Category
+        let packing = coreDataManager.createNewPacking(
+            title: "Swimming in Bondi",
+            location: "Beach",
+            startDate: Date(),
+            endDate: Date().addingTimeInterval(86400),
+            color: UIColor.red
+        )
+        
+        let category = coreDataManager.createNewCategory(
+            title: "Swimming Stuff",
+            symbol: "ferry",
+            packing: packing
+        )
+        
+        // When: Create a item associated with the Category
+        let title = "Swimming Suit"
+        
+        let item = Item(context: coreDataManager.context)
+        item.title = title
+        item.done = false
+        item.createdAt = Date()
+        item.parentCategory = category
+        
+        coreDataManager.saveContext()
+        
+        // Then: Verify the item was created and associated correctly
+        XCTAssertEqual(category.items?.count, 1, "Category should only contain one item")
+        
+        XCTAssertEqual(item.title, title, "Incorrect title for Item")
+        XCTAssertEqual(item.done, false, "Incorrect done status for Item")
+        XCTAssertEqual(item.parentCategory, category, "Item should be linked to the newly created Category")
+    }
+    
+    func testFetchItemsInCategory() {
+        // Given: Create a new Packing, Category and multiple associated Items
+        let packing = coreDataManager.createNewPacking(
+            title: "Swimming in Bondi",
+            location: "Beach",
+            startDate: Date(),
+            endDate: Date().addingTimeInterval(86400),
+            color: UIColor.red
+        )
+        
+        let category = coreDataManager.createNewCategory(
+            title: "Swimming Stuff",
+            symbol: "ferry",
+            packing: packing
+        )
+        
+        let firstItem = Item(context: coreDataManager.context)
+        firstItem.title = "Beach Ball"
+        firstItem.done = false
+        firstItem.createdAt = Date()
+        firstItem.parentCategory = category
+        
+        let secondItem = Item(context: coreDataManager.context)
+        secondItem.title = "Sunscreen"
+        secondItem.done = false
+        secondItem.createdAt = Date()
+        secondItem.parentCategory = category
+        
+        coreDataManager.saveContext()
+        
+        // When: Fetch items related to the Category
+        let items = category.items?.allObjects as? [Item]
+        
+        // Then: Verify correct Items are fetched
+        XCTAssertEqual(items?.count, 2, "There should only be 2 items in the category")
+        XCTAssertTrue(items?.contains(firstItem) ?? false, "First items hould be in the fetched items")
+        XCTAssertTrue(items?.contains(secondItem) ?? false, "Second item should be in the fetched Items")
+    }
+    
+    func testMarkItemAsDone() {
+        // Given: Create a new Packing, Category, and Item
+        let packing = coreDataManager.createNewPacking(
+            title: "Food hunting in Rome",
+            location: "City",
+            startDate: Date(),
+            endDate: Date().addingTimeInterval(86400),
+            color: UIColor.red
+        )
+        
+        let category = coreDataManager.createNewCategory(
+            title: "Supplies",
+            symbol: "house",
+            packing: packing
+        )
+        
+        let firstItem = Item(context: coreDataManager.context)
+        firstItem.title = "Travel Bag"
+        firstItem.done = false
+        firstItem.createdAt = Date()
+        firstItem.parentCategory = category
+        
+        let secondItem = Item(context: coreDataManager.context)
+        secondItem.title = "Wallet"
+        secondItem.done = true
+        secondItem.createdAt = Date()
+        secondItem.parentCategory = category
+        
+        coreDataManager.saveContext()
+        
+        // When: Mark the item as Done
+        firstItem.done = true
+        secondItem.done = false
+        coreDataManager.saveContext()
+        
+        // Then: Verify that the Item is marked as Done
+        XCTAssertTrue(firstItem.done, "First item should be marked as done.")
+        XCTAssertFalse(secondItem.done, "Second item should be marked as not done")
+    }
+    
+    //MARK: - Negative Test Cases
+    func testCreateItemWithMissingFields() {
+        // Given: Create a new Packing and Category
+        let packing = coreDataManager.createNewPacking(
+            title: "Food hunting in Rome",
+            location: "City",
+            startDate: Date(),
+            endDate: Date().addingTimeInterval(86400),
+            color: UIColor.red
+        )
+        
+        let category = coreDataManager.createNewCategory(
+            title: "Supplies",
+            symbol: "house",
+            packing: packing
+        )
+        
+        // When: Create an Item associated with the category with nil values
+        let item = Item(context: coreDataManager.context)
+        item.title = nil
+        item.done = false
+        item.parentCategory = category
+        
+        // Then: Save the Item with missing fields
+        do {
+            try coreDataManager.context.save()
+            XCTFail("Saving an Item with missing fields should have failed")
+        } catch {
+            XCTAssertNotNil(error, "Expected error due to existing missing required fields")
+        }
+    }
+    
+    func testFetchItemWithInvalidPredicate() {
+        // Given: Create a new Packing, Category, and Item
+        let packing = coreDataManager.createNewPacking(
+            title: "Sightseeing at Melbourne",
+            location: "Countryside",
+            startDate: Date(),
+            endDate: Date().addingTimeInterval(86400),
+            color: UIColor.blue
+        )
+        
+        let category = coreDataManager.createNewCategory(
+            title: "Roadtrip Stuff",
+            symbol: "sunset",
+            packing: packing
+        )
+        
+        let item = Item(context: coreDataManager.context)
+        item.title = "Power Bank"
+        item.done = false
+        item.createdAt = Date()
+        item.parentCategory = category
+        
+        coreDataManager.saveContext()
+        
+        // When: Attempt to fetch Items with predicate that won't match any entity
+        let fetchRequest: NSFetchRequest<Item> = Item.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "title == %@", "Jungle Book")
+        
+        // Then: Verify no errors are thrown and empty result is returned
+        do {
+            let result = try coreDataManager.context.fetch(fetchRequest)
+            XCTAssertTrue(result.isEmpty, "Expected no result for invalid predicate")
+        } catch {
+            XCTFail("No errors should be thrown when fetching with invalid predicate")
+        }
+    }
+}

--- a/PackBuddyTests/PackingTests.swift
+++ b/PackBuddyTests/PackingTests.swift
@@ -1,0 +1,124 @@
+//
+//  PackingTests.swift
+//  PackBuddyTests
+//
+//  Created by Jonathan Vieri on 11/11/24.
+//
+
+import XCTest
+import CoreData
+
+@testable import Pack_Buddy
+
+final class PackingTests: XCTestCase {
+    
+    //MARK: - Setup
+    
+    // Setup Core Data to use in-memory
+    lazy var persistentContainer: NSPersistentContainer = {
+        let container = NSPersistentContainer(name: "PackBuddy")
+        
+        let description = NSPersistentStoreDescription()
+        description.type = NSInMemoryStoreType
+        container.persistentStoreDescriptions = [description]
+        
+        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
+            if let error = error {
+                fatalError("Failed to load in-memory Core Data store: \(error.localizedDescription)")
+            }
+        })
+        return container
+    }()
+    
+    var context: NSManagedObjectContext {
+        return persistentContainer.viewContext
+    }
+    
+    var coreDataManager: CoreDataManager!
+    
+    override func setUp() {
+        super.setUp()
+        
+        // Initialize CoreDataManager with in-memory container
+        coreDataManager = CoreDataManager(container: persistentContainer)
+    }
+    
+    override func tearDown() {
+        // Cleanup after each test
+        coreDataManager = nil
+        super.tearDown()
+    }
+    
+    //MARK: - Positive Test Cases
+
+    func testSuccessfulCreatePacking() {
+        // Given: Setup attributes for a new Packing
+        let title = "Trip to Bali"
+        let startDate = Date()
+        let location = "Bali"
+        let endDate = Date().addingTimeInterval(86400 * 7)
+        let color = UIColor.blue
+        
+        // When: Create and save new Packing
+        let _ = coreDataManager.createNewPacking(
+            title: title,
+            location: location,
+            startDate: startDate,
+            endDate: endDate,
+            color: color
+        )
+        
+        // Then: Verify the data was saved correctly
+        let packings = coreDataManager.fetchAllPackings()
+        XCTAssertEqual(packings.count, 1, "There should be only one packing entity saved, but found \(packings.count)")
+        
+        if let packing = packings.first {
+            XCTAssertEqual(packing.title, title, "The title of packing should be \(title)")
+            XCTAssertEqual(packing.startDate, startDate, "The startDate should be \(startDate)")
+            XCTAssertEqual(packing.location, location, "The location should be \(location)")
+            XCTAssertEqual(packing.endDate, endDate, "The endDate should be \(endDate)")
+            XCTAssertEqual(packing.color, color, "The color should be \(color)")
+        } else {
+            XCTFail("No packing is saved")
+        }
+    }
+
+    func testSuccessfulFetchAllPackings() {
+        // Given: Create multiple packings
+        let _ = coreDataManager.createNewPacking(title: "Trip 1", location: "Location 1", startDate: Date(), endDate: Date().addingTimeInterval(86400), color: UIColor.red)
+        let _ = coreDataManager.createNewPacking(title: "Trip 2", location: "Location 2", startDate: Date(), endDate: Date().addingTimeInterval(86400 * 2), color: UIColor.green)
+        let _  = coreDataManager.createNewPacking(title: "Trip 3", location: "Location 3", startDate: Date(), endDate: Date().addingTimeInterval(86400 * 3), color: UIColor.blue)
+        
+        // When: Fetch all packings
+        let packings = coreDataManager.fetchAllPackings()
+        
+        // Then: Verify correct number of packings was returned
+        XCTAssertEqual(packings.count, 3, "There should only be three packing entities, but found \(packings.count)")
+    }
+    
+    func testSuccessfulFetchSortedPackings() {
+        // Given: Create multiple packings with different createdAt
+        let packing1 = coreDataManager.createNewPacking(title: "Trip 1", location: "Location 1", startDate: Date(), endDate: Date().addingTimeInterval(86400), color: UIColor.red)
+        let packing2 = coreDataManager.createNewPacking(title: "Trip 2", location: "Location 2", startDate: Date(), endDate: Date().addingTimeInterval(86400 * 2), color: UIColor.green)
+        let packing3 = coreDataManager.createNewPacking(title: "Trip 3", location: "Location 3", startDate: Date(), endDate: Date().addingTimeInterval(86400 * 3), color: UIColor.blue)
+
+        // Manually change the createdAt time
+        packing2.createdAt = Date()
+        packing1.createdAt = Date().addingTimeInterval(600)
+        packing3.createdAt = Date().addingTimeInterval(601)
+        
+        coreDataManager.saveContext()
+        
+        // When: Fetch sorted packings
+        let packings = coreDataManager.fetchSortedPackings()
+        
+        // Then: Verify sorting order
+        XCTAssertEqual(packings.count, 3, "There should only be three packing entities, but found \(packings.count)")
+        
+        XCTAssertEqual(packings[0].title, "Trip 2", "First item should be earliest item (Trip 2)")
+        XCTAssertEqual(packings[1].title, "Trip 1", "Second item should be second earliest item (Trip 1)")
+        XCTAssertEqual(packings[2].title, "Trip 3", "Third item should be the latest item (Trip 3)")
+    }
+
+    
+}

--- a/PackBuddyTests/PackingTests.swift
+++ b/PackBuddyTests/PackingTests.swift
@@ -51,7 +51,7 @@ final class PackingTests: XCTestCase {
     
     //MARK: - Positive Test Cases
 
-    func testSuccessfulCreatePacking() {
+    func testCreatePacking() {
         // Given: Setup attributes for a new Packing
         let title = "Trip to Bali"
         let startDate = Date()
@@ -83,7 +83,7 @@ final class PackingTests: XCTestCase {
         }
     }
 
-    func testSuccessfulFetchAllPackings() {
+    func testFetchAllPackings() {
         // Given: Create multiple packings
         let _ = coreDataManager.createNewPacking(title: "Trip 1", location: "Location 1", startDate: Date(), endDate: Date().addingTimeInterval(86400), color: UIColor.red)
         let _ = coreDataManager.createNewPacking(title: "Trip 2", location: "Location 2", startDate: Date(), endDate: Date().addingTimeInterval(86400 * 2), color: UIColor.green)
@@ -96,7 +96,7 @@ final class PackingTests: XCTestCase {
         XCTAssertEqual(packings.count, 3, "There should only be three packing entities, but found \(packings.count)")
     }
     
-    func testSuccessfulFetchSortedPackings() {
+    func testFetchSortedPackings() {
         // Given: Create multiple packings with different createdAt
         let packing1 = coreDataManager.createNewPacking(title: "Trip 1", location: "Location 1", startDate: Date(), endDate: Date().addingTimeInterval(86400), color: UIColor.red)
         let packing2 = coreDataManager.createNewPacking(title: "Trip 2", location: "Location 2", startDate: Date(), endDate: Date().addingTimeInterval(86400 * 2), color: UIColor.green)

--- a/PackBuddyTests/PackingTests.swift
+++ b/PackBuddyTests/PackingTests.swift
@@ -120,5 +120,36 @@ final class PackingTests: XCTestCase {
         XCTAssertEqual(packings[2].title, "Trip 3", "Third item should be the latest item (Trip 3)")
     }
 
+    //MARK: - Negative Test Cases
     
+    func testCreatePackingWithMissingFields() {
+        // Given: Create a Packing entity with missing required field
+        let packing = Packing(context: coreDataManager.context)
+        packing.title = "New Packing"
+        
+        // When: Attempt to save the context
+        do {
+            try coreDataManager.context.save()
+            XCTFail("Saving should fail due to missing required fields")
+        } catch {
+            // Then: Verify an error is thrown
+            XCTAssertNotNil(error, "Expected error due to missing required fields")
+        }
+    }
+    
+    func testFetchAllPackingsWithNoData() {
+        // When: Fetch all packings with no data
+        let packings = coreDataManager.fetchAllPackings()
+        
+        // Then: Verify result is empty
+        XCTAssertTrue(packings.isEmpty, "Expected no packings, but found \(packings.count) items")
+    }
+    
+    func testFetchSortedPackingsWithNoData() {
+        // When: Fetch sorted packings with no data
+        let packings = coreDataManager.fetchSortedPackings()
+        
+        // Then:
+        XCTAssertTrue(packings.isEmpty, "Expected no packings, but found \(packings.count) items")
+    }
 }

--- a/PackBuddyTests/PackingTests.swift
+++ b/PackBuddyTests/PackingTests.swift
@@ -22,11 +22,11 @@ final class PackingTests: XCTestCase {
         description.type = NSInMemoryStoreType
         container.persistentStoreDescriptions = [description]
         
-        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
+        container.loadPersistentStores { (storeDescription, error) in
             if let error = error {
                 fatalError("Failed to load in-memory Core Data store: \(error.localizedDescription)")
             }
-        })
+        }
         return container
     }()
     


### PR DESCRIPTION
Added unit tests for Packing, Category and Item using XCTest framework.
The tests created mainly are testing the Core Data functionality.
Also added persistentContainer injection to Core Data Manager, so the unit tests can use Core Data stack that is being stored in-memory.